### PR TITLE
HTTPS

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -22,9 +22,47 @@ http {
     gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
     server {
-        listen ${{PORT}};
-        lua_code_cache ${{CODE_CACHE}};
+        listen 80 default_server;
+        listen [::]:80 default_server;
 
+        location /.well-known/acme-challenge {
+            alias /var/lib/dehydrated/acme-challenges;
+        }
+
+        location / {
+            return 302 https://$host$request_uri;
+        }
+    }
+
+    server {
+        server_name fengari.io;
+        listen 443 ssl http2;
+        listen [::]:443 ssl http2;
+        ssl_certificate /var/lib/dehydrated/certs/fengari.io/fullchain.pem;
+        ssl_certificate_key /var/lib/dehydrated/certs/fengari.io/privkey.pem;
+        ssl_session_timeout 1d;
+        ssl_session_cache shared:SSL:50m;
+        ssl_session_tickets off;
+
+        # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+        ssl_dhparam /etc/ssl/private/dhparam.pem;
+
+        # intermediate configuration. tweak to your needs.
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
+        ssl_prefer_server_ciphers on;
+
+        # OCSP Stapling ---
+        # fetch OCSP records from URL in ssl_certificate and cache them
+        ssl_stapling on;
+        ssl_stapling_verify on;
+
+        ## verify chain of trust of OCSP response using Root CA and Intermediate certs
+        ssl_trusted_certificate /var/lib/dehydrated/certs/fengari.io/chain.pem;
+
+        resolver 8.8.8.8;
+
+        lua_code_cache ${{CODE_CACHE}};
 
         location / {
             default_type text/html;

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,19 +11,20 @@ events {
 http {
     include mime.types;
 
+    gzip on;
+    gzip_disable "msie6";
+
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
     server {
         listen ${{PORT}};
         lua_code_cache ${{CODE_CACHE}};
 
-        gzip on;
-        gzip_disable "msie6";
-
-        gzip_vary on;
-        gzip_proxied any;
-        gzip_comp_level 6;
-        gzip_buffers 16 8k;
-        gzip_http_version 1.1;
-        gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
         location / {
             default_type text/html;


### PR DESCRIPTION
This PR updates the nginx config to support HTTPS.

  - Serve http challenges from dehydrated directory
  - All other http requests are redirected to https
  - Intermediate Mozilla Ciphers are used
  - Turns on OCSP stapling

We need to install + configure [dehydrated](https://github.com/lukas2511/dehydrated) separately for this to work. Looks like there is a [package in jessie-backports](https://packages.debian.org/jessie-backports/dehydrated)